### PR TITLE
feat: add nx watch

### DIFF
--- a/project.json
+++ b/project.json
@@ -12,7 +12,11 @@
     "dev": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "vite",
+        "commands": [
+          "nx run-many --target=build --all && nx watch --all -- nx run-many --target=build --all",
+          "vite"
+        ],
+        "parallel": true,
         "cwd": "{workspaceRoot}"
       }
     },

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,13 +1,9 @@
 import { defineConfig } from 'vite'
 import glsl from 'vite-plugin-glsl'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
-import { resolve } from 'path'
 // import { visualizer } from "rollup-plugin-visualizer";
 
-export default defineConfig(({ command }) => {
-  const resolvePath = (path) => resolve(__dirname, path)
-  const isDev = command === 'serve'
-
+export default defineConfig(() => {
   return {
     root: 'src',
     plugins: [
@@ -31,22 +27,6 @@ export default defineConfig(({ command }) => {
         ]
       })
     ],
-	resolve: {
-		alias: {
-			'@8f4e/editor': resolvePath(isDev ? 'packages/editor/src/index.ts' : 'packages/editor/dist'),
-			'@8f4e/editor-state': resolvePath(isDev ? 'packages/editor/packages/editor-state/src/index.ts' : 'packages/editor/packages/editor-state/dist'),
-			'@8f4e/web-ui': resolvePath(isDev ? 'packages/editor/packages/web-ui/src/index.ts' : 'packages/editor/packages/web-ui/dist'),
-			'glugglug': resolvePath(isDev ? 'packages/editor/packages/glugglug/src/index.ts' : 'packages/editor/packages/glugglug/dist'),
-			'@8f4e/compiler/syntax': resolvePath(isDev ? 'packages/compiler/src/syntax/index.ts' : 'packages/compiler/dist/syntax'),
-			'@8f4e/compiler': resolvePath(isDev ? 'packages/compiler/src/index.ts' : 'packages/compiler/dist'),
-			'@8f4e/sprite-generator': resolvePath(isDev ? 'packages/editor/packages/sprite-generator/src/index.ts' : 'packages/editor/packages/sprite-generator/dist'),
-			'@8f4e/state-manager': resolvePath(isDev ? 'packages/editor/packages/state-manager/src/index.ts' : 'packages/editor/packages/state-manager/dist'),
-			'@8f4e/runtime-audio-worklet': resolvePath(isDev ? 'packages/runtime-audio-worklet/src/index.ts' : 'packages/runtime-audio-worklet/dist'),
-			'@8f4e/runtime-web-worker-logic': resolvePath(isDev ? 'packages/runtime-web-worker-logic/src/index.ts' : 'packages/runtime-web-worker-logic/dist'),
-			'@8f4e/runtime-main-thread-logic': resolvePath(isDev ? 'packages/runtime-main-thread-logic/src/index.ts' : 'packages/runtime-main-thread-logic/dist'),
-			'@8f4e/runtime-web-worker-midi': resolvePath(isDev ? 'packages/runtime-web-worker-midi/src/index.ts' : 'packages/runtime-web-worker-midi/dist')
-		}
-	},
     build: {
       outDir: '../dist',
       rollupOptions: {


### PR DESCRIPTION
This PR modernizes the development workflow by removing Vite-specific path aliases in favor of TypeScript's path resolution and adding an nx watch command to automatically rebuild packages during development.

Changes:

Removed custom Vite path aliases and related path resolution logic from vite.config.mjs
Added nx watch command to the dev target in project.json to automatically rebuild all packages when files change
Configured the dev target to run the watch command and Vite server in parallel
