### PR TITLE
feat: set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -52,7 +52,10 @@
     }
   },
   "release": {
-    "projects": ["*", "!glugglug"],
+    "projects": [
+      "*",
+      "!glugglug"
+    ],
     "projectsRelationship": "independent",
     "releaseTag": {
       "pattern": "{projectName}@{version}"
@@ -62,7 +65,9 @@
       "currentVersionResolver": "git-tag",
       "fallbackCurrentVersionResolver": "disk",
       "updateDependents": "always",
-      "manifestRootsToUpdate": ["{projectRoot}"]
+      "manifestRootsToUpdate": [
+        "{projectRoot}"
+      ]
     },
     "changelog": {
       "workspaceChangelog": false,
@@ -76,5 +81,6 @@
     }
   },
   "defaultBase": "HEAD~1",
-  "analytics": false
+  "analytics": false,
+  "nxCloudId": "6a172ab3f11a1d95830c5447"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/6a172ab1241e9ecdcd0367a0/workspaces/6a172ab3f11a1d95830c5447

> [!TIP]
> Run `npx nx generate ci-workflow` if you don't have a CI script configured yet.

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.