### PR TITLE
chore(ci): use nx affected checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          fetch-depth: 0
           submodules: recursive
 
       - name: Setup Node.js
@@ -36,12 +37,29 @@ jobs:
       - name: Build config package
         run: npx nx run @8f4e/config:build
 
-      - name: Run linting
+      - name: Set Nx affected SHAs
+        shell: bash
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            echo "NX_BASE=origin/${GITHUB_BASE_REF}" >> "$GITHUB_ENV"
+            echo "NX_HEAD=HEAD" >> "$GITHUB_ENV"
+          elif [[ "${{ github.event.before }}" =~ ^0+$ ]]; then
+            echo "NX_BASE=HEAD~1" >> "$GITHUB_ENV"
+            echo "NX_HEAD=${GITHUB_SHA}" >> "$GITHUB_ENV"
+          else
+            echo "NX_BASE=${{ github.event.before }}" >> "$GITHUB_ENV"
+            echo "NX_HEAD=${GITHUB_SHA}" >> "$GITHUB_ENV"
+          fi
+
+      - name: Run Biome check
         run: npx biome ci .
 
-      - name: Run typecheck
-        run: npx nx run-many --target=typecheck --all
+      - name: Run affected linting
+        run: npx nx affected --target=lint
 
-      - name: Run tests
-        run: npx nx run-many --target=test --all
+      - name: Run affected typecheck
+        run: npx nx affected --target=typecheck
+
+      - name: Run affected tests
+        run: npx nx affected --target=test
         timeout-minutes: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,8 +51,8 @@ jobs:
             echo "NX_HEAD=${GITHUB_SHA}" >> "$GITHUB_ENV"
           fi
 
-      - name: Run Biome check
-        run: npx biome ci .
+      - name: Run affected Biome checks
+        run: npx nx affected --target=lint
 
       - name: Run affected typecheck
         run: npx nx affected --target=typecheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,9 +54,6 @@ jobs:
       - name: Run Biome check
         run: npx biome ci .
 
-      - name: Run affected linting
-        run: npx nx affected --target=lint
-
       - name: Run affected typecheck
         run: npx nx affected --target=typecheck
 

--- a/nx.json
+++ b/nx.json
@@ -80,7 +80,7 @@
       "push": false
     }
   },
-  "defaultBase": "HEAD~1",
+  "defaultBase": "main",
   "analytics": false,
   "nxCloudId": "6a172ab3f11a1d95830c5447"
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
       "biome check --write --no-errors-on-unmatched"
     ],
     "*.ts": [
-      "bash -c 'npx nx run-many --target=typecheck --all'"
+      "bash -c 'npx nx affected --target=typecheck --files \"$@\"' --"
     ]
   },
   "overrides": {


### PR DESCRIPTION
## Summary
- compute `NX_BASE`/`NX_HEAD` in CI and run Nx lint/typecheck/test through `nx affected`
- run Biome through affected project `lint` targets, so Biome checks only the projects Nx marks as affected
- switch lint-staged typecheck from full `run-many --all` to `nx affected --files "$@"`
- set Nx `defaultBase` to `main` for local affected commands

## Verification
- `NX_NO_CLOUD=true npx nx affected --target=lint`
- `NX_NO_CLOUD=true npx nx affected --target=typecheck`
- `NX_NO_CLOUD=true npx nx affected --target=test`
- `NX_NO_CLOUD=true bash -c 'npx nx affected --target=typecheck --files "$@"' -- packages/compiler/src/compiler.ts`
